### PR TITLE
Anuncio de fin de colecta y evitar depósitos despistados [#38]

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,12 +52,22 @@
       </div>
       <div class="page-header">
         <div class="hero-unit">
-            <h1>Colabora con la Vaca...</h1>
-            <h1>Tienes hasta el 17 de Diciembre del 2013</h1>
+            <h1>La Fundación está a un paso de hacerse realidad.</h1>
+            <h2>Logramos la colecta <strong>(Ya terminó)</strong></h2>
+
             <hr/>
-            <p class="lead">Colabora con nosotros para la formación de la fundación más información en haz click...</p>
-            <hr/>
-            <a class="btn btn-large btn-success pull-right" href="/vacafundacion" title="Consulte mas información">Aquí</a>
+            <p class="lead">Buenas noticias, la colecta para financiar el
+            registro de La Fundación fue todo un éxtio. Logramos recaudar
+            Bs. 17.700,00 (y nos habíamos planteado Bs. 15.000,00).</p>
+	    <p>La Fundación está a un paso de hacerse realidad gracias al
+            aporte de los miembros de su comunidad.</p>
+	    <p class="lead">Es importante aclarar que la colecta ya
+            terminó. Así que por favor, no deposites ni transfieras dinero a la
+            cuenta destinada para dicha colecta.</p>
+	    <p>Si deseas apoyar a la Fundación realizando una donación, puedes
+            registrar tu correo electrónico en este formulario para avisarte
+            cuando esté registrada la Fundación y cuál sería su cuenta
+            destinada a las donaciones.</p>
         </div>
       </div>
 

--- a/vacafundacion/index.html
+++ b/vacafundacion/index.html
@@ -52,6 +52,30 @@ false});</script>
 </nav>
 <section class="row"> <!-- Cuerpo Principal 2 Columnas -->
 <div class="container"> <!-- Container de la columna -->
+
+      <div class="page-header">
+        <div class="hero-unit">
+
+            <h1>Logramos la colecta <strong>¡Ya terminó!</strong></h1>
+
+            <hr/>
+            <p class="lead">Buenas noticias, la colecta para financiar el
+            registro de La Fundación fue todo un éxtio. Logramos recaudar
+            Bs. 17.700,00 (y nos habíamos planteado Bs. 15.000,00).</p>
+	    <p>La Fundación está a un paso de hacerse realidad gracias al
+            aporte de los miembros de su comunidad.</p>
+	    <p class="lead">Es importante aclarar que la colecta ya
+            terminó. Así que por favor, no deposites ni transfieras dinero a la
+            cuenta destinada para dicha colecta.</p>
+	    <p>Si deseas apoyar a la Fundación realizando una donación, puedes
+            registrar tu correo electrónico en este formulario para avisarte
+            cuando esté registrada la Fundación y cuál sería su cuenta
+            destinada a las donaciones.</p>
+	    <p>Dejamos el resto del contenido de esta página para mantener las
+	    referencias realizadas a la misma.</p>
+        </div>
+      </div>
+
     <div class="row" id="smoothque"> <!-- ¿QUE? -->
     <div class="jumbotron">
         <h2>¿De qué trata esta colecta?</h2>
@@ -183,9 +207,9 @@ false});</script>
             <h2>Pasos para contribuir:</h2>
             <ol>
             <li>Haz un depósito </li>
-            <li>Notifica tu depósito <a
-                href="https://docs.google.com/a/vauxoo.com/forms/d/1NU6fipKIBLguLOw40jb_HnMO29w79pt-DdXsMr_MHsI/viewform"
-                target="_NEW">Aquí</a>.</li>
+            <li><del>Notifica tu depósito<a
+                href="#"
+                target="_NEW">Aquí</a>.</del>(ya no tiene validez).</li>
             </ol>
             <h2>¿Qué sucederá si sobra dinero?</h2>
             <p class="lead">
@@ -210,14 +234,7 @@ false});</script>
                 <div class="panel-heading">
                     <h3 class="panel-title">Datos de depósito</h3>
                 </div>
-                <div class="panel-body">
-                    <abbr title="Número de cuenta">Número de cuenta:</abbr> 0108-0158-35-0100207613<br/>
-                    <abbr title="Tipo de cuenta">Tipo de cuenta:</abbr> Corriente<br/>
-                    <abbr title="Banco">Banco:</abbr> Provincial<br/> 
-                    <abbr title="Beneficiario">A nombre de:</abbr> Sebastián Ramírez Magrí<br/>
-                    <abbr title="Cedula">Cedula:</abbr> V-18036923<br/>
-                    <abbr title="e-Mail">Correo electrónico:</abbr> sebasmagri en googlemail sin el oogle punto com.<br/>
-                </div>
+		<p> Esta sección fue eliminada, ya que la colecta terminó.</p>
             </div>
         </div>
         <div id="smoothcomovamos" class="col-md-6 col-lg-6"> <!-- Columna Derecha -->


### PR DESCRIPTION
Tanto en la página principal como en la destinada a la colecta se
anuncia el final de la colecta.

Adicionalmente, se quita el enlace a la página de la colecta desde
la página principal, y de la página de la colecta se borra la
información de la cuenta de Sebastían y el anlace al formulario
para registrar el aporte individual.
