### PR TITLE
Agregado archivo CNAME para la redirección a python.org.ve

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.python.org.ve


### PR DESCRIPTION
Cierra el issue #81 sin embargo, hay que esperar a que se apunten los DNS a github.